### PR TITLE
baremetal add dhcp-duid to NetworkManager config

### DIFF
--- a/templates/common/baremetal/files/baremetal-NetworkManager-kni-conf.yaml
+++ b/templates/common/baremetal/files/baremetal-NetworkManager-kni-conf.yaml
@@ -5,3 +5,5 @@ contents:
   inline: |
     [main]
     dhcp=dhclient
+    [connection]
+    ipv6.dhcp-duid=ll


### PR DESCRIPTION
Adding ipv6.dhcp-duid=ll means we get a predictable
client ID so that reservations can be made on the
DHCP server (which is needed to provide the hostname
via DHCP)

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
