### PR TITLE
baremetal: Remove .template from path in dhcp-dhclient-conf.yaml

### DIFF
--- a/templates/worker/00-worker/baremetal/files/dhcp-dhclient-conf.yaml
+++ b/templates/worker/00-worker/baremetal/files/dhcp-dhclient-conf.yaml
@@ -1,6 +1,6 @@
 filesystem: "root"
 mode: 0644
-path: "/etc/dhcp/dhclient.conf.template"
+path: "/etc/dhcp/dhclient.conf"
 contents:
   inline: |
     supersede domain-search "{{ .EtcdDiscoveryDomain }}";


### PR DESCRIPTION
This appears to get written out as /etc/dhcp/dhclient.conf.template
with no subsequent render-config templating to create the actual
/etc/dhcp/dhclient.conf - modifying the path results in the file
being correctly written.
