### PR TITLE
CRI-O to set stream address in ctrl plane

### DIFF
--- a/templates/common/baremetal/files/etc-systemd-system-crio-stream-address.conf.yaml
+++ b/templates/common/baremetal/files/etc-systemd-system-crio-stream-address.conf.yaml
@@ -1,0 +1,12 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/systemd/system/crio.service.d/20-stream-address.conf"
+contents:
+  inline: |
+    [Service]
+    ExecStart=
+    ExecStart=/usr/bin/crio \
+          --stream-address="${CONTAINER_STREAM_ADDRESS}" \
+          $CRIO_STORAGE_OPTIONS \
+          $CRIO_NETWORK_OPTIONS \
+          $CRIO_METRICS_OPTIONS


### PR DESCRIPTION
The original fix in 065082e25b5260001d724d34eee9d307c0c3e92c missed the
systemd service ExecStart override that uses the environment variable
set in /etc/systemd/system/crio.service.d